### PR TITLE
Allow efficient node manipulation with linked lists.

### DIFF
--- a/data_structures/linked_list.py
+++ b/data_structures/linked_list.py
@@ -5,54 +5,61 @@ from data_structures.node import Node
 
 class LinkedListIterator:
     """ Iterator for LinkedList. """
-    def __init__(self, head_node: Node[T], parent_list:LinkedList[T]):
-        self.__next = head_node
-        self.__curr = None
-        self.__prev = None
+    def __init__(self, parent_list:LinkedList[T]):
+        self.__curr:Node[T] | None = None
+        self.__prev:Node[T] | None = None
         self.__parent = parent_list
 
     def __iter__(self):
         return self
 
     def __next__(self) -> T:
-        if self.__next is None:
-            raise StopIteration
+        if self.__curr is None:
+            self.__curr = self.__parent._LinkedList__head
+            if self.__curr is None:
+                raise StopIteration
+            return self.__curr.item
+
         else:
-            item = self.__next.item
-            if self.__curr is not self.__next:
-                self.__prev = self.__curr
-            self.__curr = self.__next
-            self.__next = self.__next.link
-            return item
+            if self.__curr.link is None:
+                raise StopIteration
+            self.__prev = self.__curr
+            self.__curr = self.__curr.link
+            return self.__curr.item
         
     def insert_before(self, item:T):
         new_node = self.__parent._insert_after_node(item, self.__prev)
-        self.__prev = new_node
+        if self.__curr is None:
+            pass
+        else:
+            self.__prev = new_node
 
     def insert_after(self, item:T):
         self.__parent._insert_after_node(item, self.__curr)
-        if self.__curr is None:
-            self.__next = self.__parent._LinkedList__head
-        else:
-            self.__next = self.__curr.link
+        
 
     def delete_current(self):
         self.__parent._delete_after_node(self.__prev)
-        self.__curr = self.__curr.link
-        self.__next = self.__curr
+        self.__curr = self.__prev
+        
 
     def delete_next(self):
         self.__parent._delete_after_node(self.__curr)
-        self.__next = self.__next.link
+        
 
     def set_current(self, item):
         self.__curr.item = item
 
     def has_next(self) -> bool:
-        return self.__next is not None
+        return self.__get_next_node() is not None
 
     def peek(self) -> T:
-        return self.__next.item
+        return self.__get_next_node().item
+    
+    def __get_next_node(self) -> Node[T] | None:
+        if self.__curr is None:
+            return self.__parent._LinkedList__head
+        return self.__curr.link
 
 class LinkedList(List[T]):
     """ Linked-node based implementation of List ADT. """
@@ -86,7 +93,7 @@ class LinkedList(List[T]):
 
     def __iter__(self):
         """ Iterate through the list. """
-        return LinkedListIterator(self.__head, self)
+        return LinkedListIterator(self)
 
     def __contains__(self, item: T) -> bool:
         """ Check if the item is in the list. """

--- a/data_structures/linked_list.py
+++ b/data_structures/linked_list.py
@@ -1,23 +1,58 @@
+from __future__ import annotations
 from data_structures.abstract_list import List, T
 from data_structures.node import Node
 
 
 class LinkedListIterator:
     """ Iterator for LinkedList. """
-    def __init__(self, head_node: Node):
-        self.__current = head_node
+    def __init__(self, head_node: Node[T], parent_list:LinkedList[T]):
+        self.__next = head_node
+        self.__curr = None
+        self.__prev = None
+        self.__parent = parent_list
 
     def __iter__(self):
         return self
 
-    def __next__(self):
-        if self.__current is None:
+    def __next__(self) -> T:
+        if self.__next is None:
             raise StopIteration
         else:
-            item = self.__current.item
-            self.__current = self.__current.link
+            item = self.__next.item
+            if self.__curr is not self.__next:
+                self.__prev = self.__curr
+            self.__curr = self.__next
+            self.__next = self.__next.link
             return item
+        
+    def insert_before(self, item:T):
+        new_node = self.__parent._insert_after_node(item, self.__prev)
+        self.__prev = new_node
 
+    def insert_after(self, item:T):
+        self.__parent._insert_after_node(item, self.__curr)
+        if self.__curr is None:
+            self.__next = self.__parent._LinkedList__head
+        else:
+            self.__next = self.__curr.link
+
+    def delete_current(self):
+        self.__parent._delete_after_node(self.__prev)
+        self.__curr = self.__curr.link
+        self.__next = self.__curr
+
+    def delete_next(self):
+        self.__parent._delete_after_node(self.__curr)
+        self.__next = self.__next.link
+
+    def set_current(self, item):
+        self.__curr.item = item
+
+    def has_next(self) -> bool:
+        return self.__next is not None
+
+    def peek(self) -> T:
+        return self.__next.item
 
 class LinkedList(List[T]):
     """ Linked-node based implementation of List ADT. """
@@ -51,7 +86,7 @@ class LinkedList(List[T]):
 
     def __iter__(self):
         """ Iterate through the list. """
-        return LinkedListIterator(self.__head)
+        return LinkedListIterator(self.__head, self)
 
     def __contains__(self, item: T) -> bool:
         """ Check if the item is in the list. """
@@ -82,6 +117,28 @@ class LinkedList(List[T]):
             return current
         else:
             raise IndexError('Out of bounds access in list.')
+    
+    def _insert_after_node(self, item:T, node:Node[T]):
+        if node is None:
+            self.insert(0, item)
+            return self.__head
+        else:
+            new_node = Node(item)
+            new_node.link = node.link
+            node.link = new_node
+            self.__length += 1
+            if node is self.__rear:
+                self.__rear = new_node
+            return new_node
+
+    def _delete_after_node(self, node:Node[T]):
+        if node is None:
+            self.delete_at_index(0)
+        else:
+            node.link = node.link.link
+            self.__length -= 1
+            if node.link is None:
+                self.__rear = node
 
     def index(self, item: T) -> int:
         """ Find the position of a given item in the list. """

--- a/data_structures/node.py
+++ b/data_structures/node.py
@@ -11,3 +11,6 @@ class Node(Generic[T]):
     def __init__(self, item: T = None):
         self.item = item
         self.link:Node[T] | None = None
+    
+    def __str__(self) -> str:
+        return f"Node({self.item}, {'...' if self.link else 'None'})"

--- a/data_structures/node.py
+++ b/data_structures/node.py
@@ -10,4 +10,4 @@ class Node(Generic[T]):
 
     def __init__(self, item: T = None):
         self.item = item
-        self.link = None
+        self.link:Node[T] | None = None

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -204,3 +204,143 @@ class TestLinkedList(TestCase):
         for _ in range(len(self.list)):
             next(iter2)
         self.assertRaises(StopIteration, next, iter2)
+
+    def test_node_iterator(self):
+        list_iter = iter(self.list)
+        self.assertFalse(list_iter.has_next())
+        list_iter.insert_after(1)
+        self.assertTrue(list_iter.has_next())
+        self.assertEqual(len(self.list), 1)
+        self.assertIsNotNone(self.list._LinkedList__head)
+        self.assertIsNotNone(self.list._LinkedList__rear)
+        self.assertEqual(list_iter.peek(), 1)
+        
+        next(list_iter)
+        self.assertFalse(list_iter.has_next())
+        self.assertRaises(StopIteration, next, list_iter)
+        self.assertRaises(AttributeError, list_iter.delete_next)
+        self.assertRaises(AttributeError, list_iter.peek)
+
+        list_iter2 = iter(self.list)
+        list_iter2.insert_after(2)
+        self.assertIsNot(self.list._LinkedList__head, self.list._LinkedList__rear)
+        self.assertEqual([i for i in self.list], [2,1])
+        self.assertEqual(len(self.list), 2)
+
+        list_iter2.delete_next()
+        self.assertTrue(list_iter2.has_next())
+        self.assertIs(self.list._LinkedList__head, self.list._LinkedList__rear)
+        self.assertEqual([i for i in self.list], [1])
+        self.assertEqual(len(self.list), 1)
+
+        list_iter2.delete_next()
+        self.assertFalse(list_iter2.has_next())
+        self.assertIsNone(self.list._LinkedList__head)
+        self.assertIsNone(self.list._LinkedList__rear)
+        self.assertEqual(len(self.list), 0)
+
+        list_iter = iter(self.list)
+        list_iter.insert_after(1)
+        next(list_iter)
+        list_iter.insert_after(2)
+        self.assertIsNot(self.list._LinkedList__head, self.list._LinkedList__rear)
+
+    def test_delete_negatives(self):
+        for value in [-5, 2, 6, -4, -6, 4, 1, -3]:
+            self.list.append(value)
+        
+        list_iter = iter(self.list)
+        while list_iter.has_next():
+            if list_iter.peek() < 0:
+                list_iter.delete_next()
+            else:
+                next(list_iter)
+        
+        self.assertEqual([i for i in self.list], [2,6,4,1])
+        self.assertEqual(len(self.list), 4)
+
+        self.list = LinkedList()
+        for value in [-5, 2, 6, -4, -6, 4, 1, -3]:
+            self.list.append(value)
+        
+        list_iter = iter(self.list)
+        for value in list_iter:
+            if value < 0:
+                list_iter.delete_current()
+        
+        self.assertEqual([i for i in self.list], [2,6,4,1])
+        self.assertEqual(len(self.list), 4)
+
+
+        self.list = LinkedList()
+        for value in [-5, -4, -6, -3]:
+            self.list.append(value)
+        
+        list_iter = iter(self.list)
+        while list_iter.has_next():
+            if list_iter.peek() < 0:
+                list_iter.delete_next()
+            else:
+                next(list_iter)
+        
+        self.assertEqual([i for i in self.list], [])
+        self.assertEqual(len(self.list), 0)
+        self.assertIsNone(self.list._LinkedList__head)
+        self.assertIsNone(self.list._LinkedList__rear)
+
+        self.list = LinkedList()
+        for value in [-5, -4, -6, -3]:
+            self.list.append(value)
+        
+        list_iter = iter(self.list)
+        for value in list_iter:
+            if value < 0:
+                list_iter.delete_current()
+
+        self.assertEqual([i for i in self.list], [])
+        self.assertEqual(len(self.list), 0)
+        self.assertIsNone(self.list._LinkedList__head)
+        self.assertIsNone(self.list._LinkedList__rear)
+
+    
+    def test_insert_iterator(self):
+        list_iter = iter(self.list)
+        list_iter.insert_before(1)
+        self.assertEqual(len(self.list), 1)
+        self.assertIs(self.list._LinkedList__head, self.list._LinkedList__rear)
+        self.assertIsNotNone(self.list._LinkedList__head)
+        
+        list_iter.insert_before(1)
+        self.assertEqual(len(self.list), 2)
+        self.assertIsNot(self.list._LinkedList__head, self.list._LinkedList__rear)
+
+        self.list = LinkedList()
+
+        self.list.append(0)
+        list_iter = iter(self.list)
+        for v in list_iter:
+            list_iter.insert_after(v+1)
+            if v == 99:
+                break
+        
+        self.assertEqual(len(self.list), 101)
+        values = [i for i in self.list]
+
+        self.assertTrue(values == sorted(values[:]))
+        self.assertTrue(list_iter.has_next())
+
+        self.list = LinkedList()
+
+        list_iter = iter(self.list)
+        for i in range(10):
+            list_iter.insert_before(i)
+
+        values = [i for i in self.list]
+        
+        self.assertTrue(values == sorted(values[:]))
+        self.assertFalse(list_iter.has_next())
+
+
+        
+
+            

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -337,8 +337,8 @@ class TestLinkedList(TestCase):
 
         values = [i for i in self.list]
         
-        self.assertTrue(values == sorted(values[:]))
-        self.assertFalse(list_iter.has_next())
+        self.assertTrue(values == sorted(values)[::-1])
+        self.assertTrue(list_iter.has_next())
 
 
         


### PR DESCRIPTION
Without out access to manipulating the node internals of a linked list, there is little benefit of using a linked list over an array list.
This adds methods to the LinkedListIterator which allows mutation of the current node's item and insertion and deletion of nodes before and after the current node, while maintaining the internal state of the linked list (length, head and rear pointers).