### PR TITLE
Explictly add conversions for ArrayR to and from our Lists

### DIFF
--- a/data_structures/abstract_list.py
+++ b/data_structures/abstract_list.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TypeVar, Generic
+import data_structures.referential_array as ArrayR
 
 T = TypeVar('T')
 
@@ -65,4 +67,10 @@ class List(ABC, Generic[T]):
     @abstractmethod
     def clear(self) -> None:
         """ Clear the list. """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def from_arrayR(cls, array:ArrayR.ArrayR[T]) -> List[T]:
+        """ Creates a list containing everything in the ArrayR, including any Nones """
         pass

--- a/data_structures/array_list.py
+++ b/data_structures/array_list.py
@@ -133,3 +133,10 @@ class ArrayList(List[T]):
         self.__shuffle_right(index)
         self.__length += 1
         self[index] = item
+    
+    @classmethod
+    def from_arrayR(cls, array):
+        new_list = cls(len(array))
+        for i in range(len(array)):
+            new_list.append(array[i])
+        return new_list

--- a/data_structures/linked_list.py
+++ b/data_structures/linked_list.py
@@ -151,3 +151,10 @@ class LinkedList(List[T]):
 
     def __repr__(self) -> str:
         return str(self)
+
+    @classmethod
+    def from_arrayR(cls, array):
+        new_list = cls()
+        for i in range(len(array)):
+            new_list.append(array[i])
+        return new_list

--- a/data_structures/referential_array.py
+++ b/data_structures/referential_array.py
@@ -22,6 +22,7 @@ __docformat__ = 'reStructuredText'
 
 from ctypes import py_object
 from typing import Generic, Union, TypeVar
+from data_structures.abstract_list import List
 
 T = TypeVar('T')
 
@@ -59,19 +60,13 @@ class ArrayR(Generic[T]):
         self.array[index] = value
 
     @classmethod
-    def from_list(cls, lst: list) -> ArrayR:
-        """ Creates an ArrayR from a list
+    def from_list(cls, lst: list[T] | List[T]) -> ArrayR[T]:
+        """ Creates an ArrayR from a python list, or ArrayList or LinkedList 
         :complexity: O(n) where n is the length of the list
         """
         new_array = cls(len(lst))
         new_array.array[:] = lst
         return new_array
-
-    def to_list(self) -> list:
-        """ Returns a list representation of the array
-        :complexity: O(n) where n is the length of the array
-        """
-        return [self.array[i] for i in range(len(self))]
 
     def __str__(self) -> str:
         """ Returns a string representation of the array

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 from data_structures.linked_list import LinkedList
 from data_structures.array_list import ArrayList
+from data_structures.referential_array import ArrayR
 
 
 class TestArrayList(TestCase):
@@ -204,3 +205,46 @@ class TestLinkedList(TestCase):
         for _ in range(len(self.list)):
             next(iter2)
         self.assertRaises(StopIteration, next, iter2)
+
+class TestArrayRConversions(TestCase):
+    def test_from_ArrayList(self):
+        al = ArrayList(5)
+        for i in range(4):
+            al.append(i)
+        
+        ar = ArrayR.from_list(al)
+
+        for i in range(len(ar)):
+            self.assertEqual(ar[i], al[i])
+        
+        self.assertEqual(len(ar), 4)
+
+    def test_from_LinkedList(self):
+        ll = LinkedList()
+        for i in range(4):
+            ll.append(i)
+        
+        ar = ArrayR.from_list(ll)
+
+        for i in range(len(ar)):
+            self.assertEqual(ar[i], ll[i])
+        
+        self.assertEqual(len(ar), 4)
+
+    def test_to_array_list(self):
+        array = ArrayR(5)
+        for i in range(4):
+            array[i] = i
+        
+        array_list = ArrayList.from_arrayR(array)
+        self.assertEqual([n for n in array_list], [0,1,2,3, None])
+        self.assertEqual(len(array_list), 5)
+
+    def test_to_linked_list(self):
+        array = ArrayR(5)
+        for i in range(4):
+            array[i] = i
+        
+        linked_list = LinkedList.from_arrayR(array)
+        self.assertEqual([n for n in linked_list], [0,1,2,3, None])
+        self.assertEqual(len(linked_list), 5)


### PR DESCRIPTION
I just marked an assignment that had `return ArrayR.from_list([n for n in ArrayList(...)])`, which failed the inbuilts test.
This adds to the docstring that the `ArrayR.from_list()` works with our custom lists and adds options to convert the ArrayR to an ArrayList or LinkedList instead of the banned python list.