### PR TITLE
Fix complexity of LinkedList[-1], add tests for negative indices, refactor List tests.

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,4 +37,4 @@ jobs:
     #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with unittest
       run: |
-        python -m unittest
+        python -m unittest -k Test

--- a/data_structures/abstract_list.py
+++ b/data_structures/abstract_list.py
@@ -42,6 +42,12 @@ class List(ABC, Generic[T], DunderProtected):
         """ Clear the list. """
         pass
 
+    def _absolute_index(self, index):
+        """ Convert negative index into positive index """
+        if index < 0:
+            return len(self) + index
+        return index
+
     @abstractmethod
     def __getitem__(self, index: int) -> T:
         """ Return the element at the given position. """

--- a/data_structures/abstract_sorted_list.py
+++ b/data_structures/abstract_sorted_list.py
@@ -16,6 +16,12 @@ class SortedList(ABC, Generic[T], DunderProtected):
         """ Add new element to the list. """
         pass
 
+    def _absolute_index(self, index):
+        """ Convert negative index into positive index """
+        if index < 0:
+            return len(self) + index
+        return index
+
     @abstractmethod
     def delete_at_index(self, index: int) -> T:
         """ Delete item at a given position. """

--- a/data_structures/array_list.py
+++ b/data_structures/array_list.py
@@ -21,6 +21,7 @@ class ArrayList(List[T]):
                      is the number of items in the list.
         """
         # Ensure index is valid
+        index = self._absolute_index(index)
         if index < 0 or index > len(self):
             raise IndexError("Index out of bounds")
 
@@ -35,11 +36,12 @@ class ArrayList(List[T]):
     def delete_at_index(self, index: int) -> T:
         """ Delete item at the given index.
         It will shuffle all the items to the left from index to fill the empty spot.
-        :pre: index is 0 <= index < len(self) - this is checked by __getitem__() !
+        :pre: index is -len(self) <= index < len(self) - this is checked by __getitem__() !
         :complexity: See __shuffle_left()
         """
         item = self[index]
-        self.__shuffle_left(index)
+        pos_index = self._absolute_index(index)
+        self.__shuffle_left(pos_index)
         self.__length -= 1
         return item
 
@@ -113,10 +115,9 @@ class ArrayList(List[T]):
         :complexity: O(1)
         :pre: index must be between [-self(len), len(self)]
         """
-        if index < -1 * len(self) or index >= len(self):
+        index = self._absolute_index(index)
+        if index < 0 or index >= len(self):
             raise IndexError("Out of bounds access in list.")
-        if index < 0:
-            index = len(self) + index
         return self.__array[index]
 
     def __setitem__(self, index: int, value: T) -> None:

--- a/data_structures/array_sorted_list.py
+++ b/data_structures/array_sorted_list.py
@@ -39,6 +39,7 @@ class ArraySortedList(SortedList[T]):
               number of items in the list.
         """
         item = self[index]
+        index = self._absolute_index(index)
         self.__shuffle_left(index)
         self.__length -= 1
         return item
@@ -132,10 +133,9 @@ class ArraySortedList(SortedList[T]):
         :raises IndexError: if the index is out of bounds.
         :complexity: O(1)
         """
-        if index < -1 * len(self) or index >= len(self):
+        index = self._absolute_index(index)
+        if index < 0 or index >= len(self):
             raise IndexError('Out of bounds access in list.')
-        if index < 0:
-            index = len(self) + index
         return self.__array[index]
 
     def __str__(self) -> str:

--- a/data_structures/linked_list.py
+++ b/data_structures/linked_list.py
@@ -75,7 +75,8 @@ class LinkedList(List[T]):
             Worst: O(N) Deleting the last item in the list, where N is the number of items in the list.
         """
         if not self.is_empty():
-            if index > 0:
+            index = self._absolute_index(index)
+            if index > 0 and index < len(self):
                 previous_node = self.__get_node_at_index(index-1)
                 item = previous_node.link.item
                 previous_node.link = previous_node.link.link
@@ -84,7 +85,7 @@ class LinkedList(List[T]):
                 self.__head = self.__head.link
                 previous_node = self.__head
             else:
-                raise ValueError("Index out of bounds")
+                raise IndexError("Index out of bounds")
 
             if index == len(self) - 1:
                 self.__rear = previous_node
@@ -120,10 +121,9 @@ class LinkedList(List[T]):
             Worst: O(N) where N is the number of items in the list. Happens when the item is close
                 to the end of the list or it doesn't exist in the list.
         """
-        if -1 * len(self) <= index and index < len(self):
-            if index < 0:
-                index = len(self) + index
-            elif index == len(self) - 1:
+        index = self._absolute_index(index)
+        if 0 <= index and index < len(self):
+            if index == len(self) - 1:
                 return self.__rear
             current = self.__head
             for _ in range(index):

--- a/prepull.py
+++ b/prepull.py
@@ -14,5 +14,7 @@ if __name__ == '__main__':
         sys.executable, 
         "-m",
         "unittest",
+        "-k",
+        "Test"
     ])
 

--- a/tests/test_hash_tables.py
+++ b/tests/test_hash_tables.py
@@ -23,7 +23,7 @@ class TestHashTableSeparateChaining(TestCase):
     def setUp(self):
         self.table = HashTableSeparateChaining()
 
-class TetsHashTables(TestCase):
+class TestHashTables(TestCase):
     def setUp(self):
         self.dictionaries = [
             LinearProbeTable(),

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from abc import ABC, abstractmethod
 
 from data_structures.linked_list import LinkedList
 from data_structures.array_list import ArrayList
@@ -6,19 +7,9 @@ from data_structures.array_sorted_list import ArraySortedList
 from data_structures.referential_array import ArrayR
 from data_structures.abstract_list import List
 
-
-class TestArrayList(TestCase):
+class BaseListtests(TestCase):
     def setUp(self):
-        self.list = ArrayList()
-    
-    def test_capacity(self):
-        # These should work
-        ArrayList(10)
-        ArrayList(0)
-        
-        # This should raise ValueError
-        with self.assertRaises(ValueError):
-            ArrayList(-1)
+        self.list:List
 
     def test_append(self):
         self.list.append(1)
@@ -60,6 +51,50 @@ class TestArrayList(TestCase):
         self.assertEqual(len(self.list), 0)
         self.assertTrue(self.list.is_empty())
     
+    def test_delete_at_index(self):
+        self.list.append(1)
+        self.list.append(2)
+        self.list.append(3)
+
+        self.assertEqual(len(self.list), 3)
+
+        self.list.delete_at_index(2)
+        self.assertEqual(len(self.list), 2)
+        self.assertEqual(self.list[0], 1)
+        self.assertEqual(self.list[1], 2)
+        self.assertRaises(IndexError, lambda: self.list.delete_at_index(2))
+
+        self.list.delete_at_index(0)
+        self.assertEqual(len(self.list), 1)
+        self.assertEqual(self.list[0], 2)
+        self.assertRaises(IndexError, lambda: self.list.delete_at_index(1))
+
+        self.list.delete_at_index(0)
+        self.assertEqual(len(self.list), 0)
+        self.assertTrue(self.list.is_empty())
+    
+    def test_delete_at_negative_index(self):
+        self.list.append(1)
+        self.list.append(2)
+        self.list.append(3)
+
+        self.assertEqual(len(self.list), 3)
+
+        self.list.delete_at_index(-1)
+        self.assertEqual(len(self.list), 2)
+        self.assertEqual(self.list[-2], 1)
+        self.assertEqual(self.list[-1], 2)
+        self.assertRaises(IndexError, lambda: self.list.delete_at_index(-3))
+
+        self.list.delete_at_index(-2)
+        self.assertEqual(len(self.list), 1)
+        self.assertEqual(self.list[-1], 2)
+        self.assertRaises(IndexError, lambda: self.list.delete_at_index(-2))
+
+        self.list.delete_at_index(-1)
+        self.assertEqual(len(self.list), 0)
+        self.assertTrue(self.list.is_empty())
+
     def test_clear(self):
         for i in range(10):
             self.list.append(i)
@@ -105,6 +140,7 @@ class TestArrayList(TestCase):
 
         self.assertRaises(IndexError, lambda: self.list[2])
         self.assertRaises(IndexError, lambda: self.list[-3])
+        self.assertEqual(list(self.list), [0, 1])
 
     def test_contains(self):
         self.list.append(1)
@@ -115,6 +151,30 @@ class TestArrayList(TestCase):
         self.assertTrue(3 in self.list)
         self.assertFalse(4 in self.list)
 
+    def test_convert_to_arrayR(self):
+        empty_array = ArrayR.from_list(self.list)
+        for i in range(5):
+            self.list.append(i)
+        array = ArrayR.from_list(self.list)
+        self.assertEqual(len(empty_array), 0)
+        self.assertEqual(len(array), 5)
+        for i in range(5):
+            self.assertIn(i, array)
+
+class TestArrayList(BaseListtests):
+    def setUp(self):
+        self.list = ArrayList()
+    
+    def test_capacity(self):
+        # These should work
+        ArrayList(10)
+        ArrayList(0)
+        
+        # This should raise ValueError
+        with self.assertRaises(ValueError):
+            ArrayList(-1)
+
+    
     def test_str(self):
         self.assertEqual(str(self.list), '<ArrayList []>')
 
@@ -140,6 +200,11 @@ class TestSortedList(TestCase):
         self.assertEqual(self.list[1], 2)
         self.assertEqual(self.list[2], 3)
 
+        #Check negative indexing
+        self.assertEqual(self.list[-3], 1)
+        self.assertEqual(self.list[-2], 2)
+        self.assertEqual(self.list[-1], 3)
+
     def test_delete_at_index(self):
         self.list.add(1)
         self.list.add(2)
@@ -159,6 +224,28 @@ class TestSortedList(TestCase):
         self.assertRaises(IndexError, lambda: self.list.delete_at_index(1))
 
         self.list.delete_at_index(0)
+        self.assertEqual(len(self.list), 0)
+        self.assertTrue(self.list.is_empty())
+    
+    def test_delete_at_negative_index(self):
+        self.list.add(1)
+        self.list.add(2)
+        self.list.add(3)
+
+        self.assertEqual(len(self.list), 3)
+
+        self.list.delete_at_index(-1)
+        self.assertEqual(len(self.list), 2)
+        self.assertEqual(self.list[0], 1)
+        self.assertEqual(self.list[1], 2)
+        self.assertRaises(IndexError, lambda: self.list.delete_at_index(-3))
+
+        self.list.delete_at_index(-2)
+        self.assertEqual(len(self.list), 1)
+        self.assertEqual(self.list[0], 2)
+        self.assertRaises(IndexError, lambda: self.list.delete_at_index(-2))
+
+        self.list.delete_at_index(-1)
         self.assertEqual(len(self.list), 0)
         self.assertTrue(self.list.is_empty())
 
@@ -222,95 +309,10 @@ class TestSortedList(TestCase):
         self.list.add(2)
         self.assertEqual(str(self.list), '<ArraySortedList [1, 2]>')
 
-class TestLinkedList(TestCase):
+class TestLinkedList(BaseListtests):
     def setUp(self):
         self.list = LinkedList()
     
-    def test_append(self):
-        self.list.append(1)
-        self.assertEqual(len(self.list), 1)
-        self.list.append(2)
-        self.assertEqual(len(self.list), 2)
-        
-        self.assertEqual(self.list[0], 1)
-        self.assertEqual(self.list[1], 2)
-
-    def test_insert(self):
-        self.list.insert(0, 1)
-        self.assertEqual(len(self.list), 1)
-        self.list.insert(1, 2)
-        self.assertEqual(len(self.list), 2)
-        self.list.insert(1, 3)
-        self.assertEqual(len(self.list), 3)
-        
-        self.assertEqual(self.list[0], 1)
-        self.assertEqual(self.list[1], 3)
-        self.assertEqual(self.list[2], 2)
-    
-    def test_remove(self):
-        self.list.append(1)
-        self.list.append(2)
-        self.list.append(3)
-        self.assertEqual(len(self.list), 3)
-        
-        self.list.remove(1)
-        self.assertEqual(len(self.list), 2)
-        self.assertEqual(self.list[0], 2)
-        self.assertEqual(self.list[1], 3)
-        
-        self.list.remove(3)
-        self.assertEqual(len(self.list), 1)
-        self.assertEqual(self.list[0], 2)
-
-        self.list.remove(2)
-        self.assertEqual(len(self.list), 0)
-        self.assertTrue(self.list.is_empty())
-    
-    def test_clear(self):
-        for i in range(10):
-            self.list.append(i)
-        self.assertEqual(len(self.list), 10)
-
-        self.list.clear()
-        self.assertEqual(len(self.list), 0)
-        self.assertTrue(self.list.is_empty())
-    
-    def test_index(self):
-        for i in range(10):
-            self.list.append(i + 1)
-        
-        self.assertEqual(self.list.index(1), 0)
-        self.assertEqual(self.list.index(5), 4)
-        self.assertEqual(self.list.index(10), 9)
-
-        # Add a second 1
-        self.list.append(1)
-        # Should still return the first 1
-        self.assertEqual(self.list.index(1), 0)
-    
-    def test_len(self):
-        for i in range(10):
-            self.list.append(i)
-            self.assertEqual(len(self.list), i + 1)
-        
-        for i in range(10):
-            self.list.remove(i)
-            self.assertEqual(len(self.list), 9 - i)
-
-    def test_getitem(self):
-        self.assertRaises(IndexError, lambda: self.list[0])
-        self.assertRaises(IndexError, lambda: self.list[-1])
-
-        self.list.append(0)
-        self.list.append(1)
-        self.assertEqual(self.list[0], 0)
-        self.assertEqual(self.list[1], 1)
-        self.assertEqual(self.list[-1], 1)
-        self.assertEqual(self.list[-2], 0)
-
-        self.assertRaises(IndexError, lambda: self.list[2])
-        self.assertRaises(IndexError, lambda: self.list[-3])
-
     def test_iteration(self):
         self.list.append(1)
         self.list.append(2)
@@ -332,18 +334,3 @@ class TestLinkedList(TestCase):
 
         self.list.append(2)
         self.assertEqual(str(self.list), '<LinkedList [1, 2]>')
-
-class TestLists(TestCase):
-    def setUp(self):
-        self.lists:list[List] = [ArrayList(), LinkedList()]
-        self.empty_lists = [ArrayList(), LinkedList()]
-        [list.append(i) for i in range(5) for list in self.lists]
-
-    def test_convert_to_arrayR(self):
-        arrays = [ArrayR.from_list(list) for list in self.lists]
-        empty_arrays = [ArrayR.from_list(list) for list in self.empty_lists]
-        self.assertEqual(list(map(len, arrays)), [5,5])
-        self.assertEqual(list(map(len, empty_arrays)), [0,0])
-        for i in range(5):
-            for array in arrays:
-                self.assertIn(i, array)


### PR DESCRIPTION
On an Ed post I saw that the complexity of LinkedList[-1] was not the same as LinkedList[len(self) - 1]. This PR fixes that.
Arguably, we should maybe also put the check for `0 <= index < len(self)` into `_absolute_index`.