### PR TITLE
Add resizing max heaps

### DIFF
--- a/data_structures/array_max_heap.py
+++ b/data_structures/array_max_heap.py
@@ -4,20 +4,23 @@ from data_structures.abstract_heap import AbstractHeap, T
 from typing import Literal, Iterable
 
 class ArrayMaxHeap(AbstractHeap[T]):
-    def __init__(self, max_items:int = 1):
-        if not max_items >= 0:
+    def __init__(self, initial_capacity:int = 1):
+        if not initial_capacity >= 0:
             raise ValueError("Heap must store 0 or more items.")
-        self.__array = ArrayR[T](max_items + 1)
+        self.__array = ArrayR[T](initial_capacity + 1)
         self.__length:int = 0
 
     def add(self, item: T) -> None:
         """ Add an item to the heap.
-        :raises ValueError: if the heap's array is full
         :complexity best: O(1) the item is adding to the end of the array (no rising required)
         :complexity worst: O(logN) Need to rise the item to the top of the heap (N is the size of the heap)
         """
         if self.is_full():
-            raise ValueError("Cannot add to full heap.")
+            
+            new_array = ArrayR(len(self.__array) * 2)
+            for i, old_item in enumerate(self.__array):
+                new_array[i] = old_item
+            self.__array = new_array
 
         self.__length += 1
         self.__array[len(self)] = item

--- a/tests/test_heaps.py
+++ b/tests/test_heaps.py
@@ -61,6 +61,14 @@ class TestMinArrayHeap(TestCase):
 
 class TestMaxArrayHeap(TestCase):
 
+    def test_add_resize(self):
+        heap = ArrayMaxHeap(2)
+        for i in range(20):
+            heap.add(i)
+        items = [heap.extract_max() for _ in range(20)]
+        self.assertEqual(items, list(range(19, -1, -1)))
+
+
     def test_heapify_resize(self):
         generator = (i for i in range(10))
         self.assertRaises(TypeError, lambda: len(generator))
@@ -108,7 +116,10 @@ class TestArrayHeaps(TestCase):
                 self.assertTrue(check_heap_ordering(heap, ordering), str(heap))
             self.assertEqual(self.CAPACITY, len(heap), str(heap))
 
-            self.assertRaises(ValueError, lambda: heap.add(1))
+            if type(heap) is not ArrayMaxHeap:
+                self.assertRaises(ValueError, lambda: heap.add(1))
+            else:
+                heap.add(1)
     
     
     def test_extract(self):


### PR DESCRIPTION
This may make it easier to hide the correct choice of data structure in A3a, as now both BST and heap do not need a max capacity.